### PR TITLE
chore: update renovate automerge rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,10 +3,22 @@
   "extends": [
     "local>peaceiris/renovate-config"
   ],
+  "major": { "minimumReleaseAge": "63 days" },
+  "minor": { "minimumReleaseAge": "21 days" },
+  "patch": { "minimumReleaseAge": "14 days" },
   "packageRules": [
     {
-      "automerge": false,
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["/.*/"],
+      "automerge": false
+    },
+    {
+      "matchPackageNames": [
+        "mdbook",
+        "peaceiris/mdbook",
+        "rust",
+        "alpine"
+      ],
+      "automerge": true,
       "automergeStrategy": "squash"
     }
   ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to enforce minimum release age thresholds: 63 days for major updates, 21 days for minor, and 14 days for patch updates.
  * Modified automerge policy to selectively enable automatic merging for specific packages while disabling it for others.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/peaceiris/docker-mdbook/pull/212)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->